### PR TITLE
Upstream gstlearn changes

### DIFF
--- a/.github/workflows/publish_python_macos.yml
+++ b/.github/workflows/publish_python_macos.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}} twine wheel setuptools
+        python -m pip install numpy==${{matrix.python.nu}} twine build
 
     - name : Create Wheels
       run : |
@@ -72,7 +72,7 @@ jobs:
         cmake --build ${{env.BUILD_DIR}} --target python_build
         cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python setup.py bdist_wheel
+        python -m build --wheel
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish_python_ubuntu.yml
+++ b/.github/workflows/publish_python_ubuntu.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install Python dependencies
+      run: |
+        export PATH=/opt/python/${{matrix.python}}/bin:$PATH
+        python3 -m pip install build
+
     - name : Create Wheels
       run : |
         export PATH=/opt/python/${{matrix.python}}/bin:$PATH
@@ -48,7 +53,7 @@ jobs:
         cmake --build ${{env.BUILD_DIR}} --target python_build
         cd ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python3 setup.py bdist_wheel --plat-name=${{env.BUILD_PLAT}}
+        python3 -m build --wheel -C="--build-option=--plat-name=${{env.BUILD_PLAT}}"
         cd ../../..
         echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish_python_windows.yml
+++ b/.github/workflows/publish_python_windows.yml
@@ -59,7 +59,7 @@ jobs:
       # Force specific old version for Numpy
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==${{matrix.python.nu}} twine wheel setuptools
+        python -m pip install numpy==${{matrix.python.nu}} twine build
 
     - name : Create Wheels
       run : |
@@ -67,7 +67,7 @@ jobs:
         cmake --build ${{env.BUILD_DIR}} --target python_build --config ${{env.BUILD_TYPE}}
         cd ${{env.BUILD_DIR}}\python\${{env.BUILD_TYPE}}
         # Note: wheel must be declared not pure (see setup.py)
-        python setup.py bdist_wheel --plat-name=${{matrix.arch.pl}}
+        python -m build --wheel -C="--build-option=--plat-name=${{matrix.arch.pl}}"
         cd ..\..\..
         $PKG_PATH = Get-ChildItem -Path "${{env.BUILD_DIR}}/python/${{env.BUILD_TYPE}}/dist/*" -File
         echo "MY_PKG=$PKG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,13 @@ include(cmake/install.cmake)
 ####################################################
 ## PACKAGES
 
-add_subdirectory(python)
-add_subdirectory(r)
+if(BUILD_PYTHON)
+  add_subdirectory(python)
+endif()
+
+if(BUILD_R)
+  add_subdirectory(r)
+endif()
 
 ####################################################
 ## TESTING

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -20,6 +20,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 if (MSVC)
   # Warning level 4 (4 = maximum, 0 = none)
   add_compile_options(/W4 /wd4251 /wd4244) # Except those two warnings
+  # Silence MSVC warnings about unsafe C standard library functions
+  add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
   # Lots of warnings (-Wall = add some warnings, -Wextra = add a ton of warnings)
   add_compile_options(-Wall -Wextra)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -122,8 +122,13 @@ endif()
 # Generate setup.py automatically for each configuration
 # First step: replace variables (@VAR@)
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in 
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/setup.py.in
+  @ONLY
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in
+  ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml.in
   @ONLY
 )
 
@@ -131,6 +136,10 @@ configure_file(
 file(GENERATE
   OUTPUT ${PYTHON_PACKAGE_ROOT_FOLDER}/setup.py
   INPUT ${CMAKE_CURRENT_BINARY_DIR}/setup.py.in
+)
+file(GENERATE
+  OUTPUT ${PYTHON_PACKAGE_ROOT_FOLDER}/pyproject.toml
+  INPUT ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml.in
 )
 
 # Generate version.py automatically for each configuration

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -73,8 +73,20 @@ if (APPLE)
   set_target_properties(python_build PROPERTIES SUFFIX ".so")
 endif()
 
-# Link to static library
-target_link_libraries(python_build PUBLIC ${PROJECT_NAME}::static)
+# Reuse shared library objects
+target_sources(
+  python_build
+  PRIVATE
+  $<TARGET_OBJECTS:${PROJECT_NAME}::shared>
+)
+target_include_directories(python_build
+  PRIVATE
+  $<TARGET_PROPERTY:${PROJECT_NAME}::shared,INCLUDE_DIRECTORIES>
+)
+target_link_libraries(python_build
+  PRIVATE
+  $<TARGET_PROPERTY:${PROJECT_NAME}::shared,LINK_LIBRARIES>
+)
 
 # Transmit the fact that we are linking to static ${PROJECT_NAME} library
 set(COMP_FLAGS "-D${PROJECT_NAME_UP}_STATIC_DEFINE")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -87,8 +87,6 @@ endif()
 
 # Set some properties on SWIG target
 set_target_properties(python_build PROPERTIES
-  # Do not build python package by default
-  EXCLUDE_FROM_ALL ON
   # Modify the generated library name
   OUTPUT_NAME ${PROJECT_NAME}
   # Compiler flags for the SWIG library

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "@PYTHON_PACKAGE_NAME@"
+version = "@PROJECT_VERSION@"
+authors = [
+  {name = "Fabien Ors", email = "fabien.ors@minesparis.psl.eu"}
+]
+description = "@PROJECT_DESCRIPTION@"
+readme = "README.md"
+license = {text = 'BSD-3-Clause'}
+requires-python = '>=3.8'
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: C++",
+    "Development Status :: 4 - Beta",
+    "Environment :: Other Environment",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "numpy==@Python3_NumPy_VERSION@",
+]
+
+[project.urls]
+Homepage = "@PROJECT_HOMEPAGE_URL@"
+Issues = "@PROJECT_HOMEPAGE_URL@/issues"
+
+[tool.setuptools]
+py-modules = []
+packages = ["@PYTHON_PACKAGE_NAME@"]
+package-data = {"@PYTHON_PACKAGE_NAME@" = ["$<TARGET_FILE_NAME:python_build>"]}
+platforms = ["Windows", "Linux", "Mac OS-X"]

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,49 +1,20 @@
-from setuptools import setup
+import setuptools
+from setuptools.command.build_ext import build_ext
 
-# Set pure is mandatory in order to ensure that wheel names are python dependent
-# Decorate wheel output file with platform name
-# https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-    class bdist_wheel(_bdist_wheel):
-        def finalize_options(self):
-            _bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-except ImportError:
-    bdist_wheel = None
 
-def get_long_description():
-    with open("README.md", "r", encoding="utf-8") as fh:
-        long_description = fh.read()
-    return long_description
+class DummyExtensionBuild(build_ext):
+    def run(self) -> None:
+        return
 
-setup(
-    name="@PYTHON_PACKAGE_NAME@",
-    version="@PROJECT_VERSION@",
-    author="Fabien Ors",
-    author_email="fabien.ors@minesparis.psl.eu",
-    description="@PROJECT_DESCRIPTION@",
-    long_description=get_long_description(),
-    long_description_content_type="text/markdown",
-    url="@PROJECT_HOMEPAGE_URL@",
-    project_urls={
-        "Bug Tracker": "@PROJECT_HOMEPAGE_URL@/issues",
-    },
-    packages={"@PYTHON_PACKAGE_NAME@"},
-    package_data={"@PYTHON_PACKAGE_NAME@":["$<TARGET_FILE_NAME:python_build>"]},
-    include_package_data=True,
-    cmdclass={'bdist_wheel': bdist_wheel},
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Programming Language :: C++",
-        "Development Status :: 4 - Beta",
-        "Environment :: Other Environment",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Topic :: Software Development :: Libraries :: Python Modules",
+
+setuptools.setup(
+    # we add an empty dummy extension to get a platform wheel...
+    ext_modules=[
+        setuptools.Extension(
+            name="dummy_extension_for_platform_wheel",
+            sources=[],
+        )
     ],
-    install_requires=[
-        "numpy",
-    ],
+    # ...and we make sure to skip its compilation
+    cmdclass={"build_ext": DummyExtensionBuild},
 )

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -88,8 +88,6 @@ set(COMP_FLAGS "-D${PROJECT_NAME_UP}_STATIC_DEFINE -Wno-unused-parameter -Wno-un
 
 # Set some properties on SWIG target
 set_target_properties(r_build PROPERTIES
-  # Do not build R package by default
-  EXCLUDE_FROM_ALL ON
   # Modify the generated library name
   OUTPUT_NAME ${PROJECT_NAME}
   # Compiler flags for the SWIG library

--- a/r/CMakeLists.txt
+++ b/r/CMakeLists.txt
@@ -80,8 +80,20 @@ if (APPLE)
   set_target_properties(r_build PROPERTIES SUFFIX ".so")
 endif()
 
-# Link to static library
-target_link_libraries(r_build PUBLIC ${PROJECT_NAME}::static)
+# Reuse shared library objects
+target_sources(
+  r_build
+  PRIVATE
+  $<TARGET_OBJECTS:${PROJECT_NAME}::shared>
+)
+target_include_directories(r_build
+  PRIVATE
+  $<TARGET_PROPERTY:${PROJECT_NAME}::shared,INCLUDE_DIRECTORIES>
+)
+target_link_libraries(r_build
+  PRIVATE
+  $<TARGET_PROPERTY:${PROJECT_NAME}::shared,LINK_LIBRARIES>
+)
 
 # Transmit the fact that we are linking to static ${PROJECT_NAME} library
 set(COMP_FLAGS "-D${PROJECT_NAME_UP}_STATIC_DEFINE -Wno-unused-parameter -Wno-unused-variable -Wno-uninitialized -Wno-cast-function-type")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,8 +10,7 @@ if (IS_MULTI_CONFIG)
 endif()
 set(MY_CTEST_COMMAND ${CMAKE_CTEST_COMMAND} ${VERBOSE_TEST} ${CONFIG_TEST} --output-on-failure)
 
-add_subdirectory(cpp)
-set(CHECK_DEP check_cpp)
+set(CHECK_DEP "")
 
 if (BUILD_PYTHON)
   add_subdirectory(py)
@@ -22,5 +21,9 @@ if (BUILD_R)
   add_subdirectory(r)
   list(APPEND CHECK_DEP check_r)
 endif()
+
+# include check_cpp last to be executed first (MSYS/R)...
+add_subdirectory(cpp)
+list(APPEND CHECK_DEP check_cpp)
 
 add_dependencies(check ${CHECK_DEP})


### PR DESCRIPTION
This PR applies the changes I made in several gstlearn PRs, in particular around CMake, R and Python.

- Switch from `setup.py` + `wheel` to `pyproject.toml` + `build`
- Use shared library objects in Python and R wrappers
- Other CMake improvements.

Enjoy,
Pierre
