### PR TITLE
Better fix for r_build/check_cpp on MSYS with shared objects

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ if (IS_MULTI_CONFIG)
 endif()
 set(MY_CTEST_COMMAND ${CMAKE_CTEST_COMMAND} ${VERBOSE_TEST} ${CONFIG_TEST} --output-on-failure)
 
-set(CHECK_DEP "")
+add_subdirectory(cpp)
+set(CHECK_DEP check_cpp)
 
 if (BUILD_PYTHON)
   add_subdirectory(py)
@@ -21,9 +22,5 @@ if (BUILD_R)
   add_subdirectory(r)
   list(APPEND CHECK_DEP check_r)
 endif()
-
-# include check_cpp last to be executed first (MSYS/R)...
-add_subdirectory(cpp)
-list(APPEND CHECK_DEP check_cpp)
 
 add_dependencies(check ${CHECK_DEP})

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -15,10 +15,21 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_DST_DIR})
 # Define the prepare target to create the output directory for logs
 if (WIN32)
   # Need to copy C++ shared library to tests directory
-  add_custom_target(prepare_cpp
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${TEST_DST_DIR}
-  )
+  if(MSYS)
+    add_custom_target(prepare_cpp
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${TEST_DST_DIR}
+      # have both lib${PROJECT_NAME}.dll and ${PROJECT_NAME}.dll in ${TEST_DST_DIR}
+      # this fixes a bug on MSYS when building R wrappers with shared
+      # objects before linking C++ test binaries
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TEST_DST_DIR}/lib${PROJECT_NAME}.dll ${TEST_DST_DIR}/${PROJECT_NAME}.dll
+    )
+  else()
+    add_custom_target(prepare_cpp
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}::shared> ${TEST_DST_DIR}
+    )
+  endif()
 else()
   add_custom_target(prepare_cpp
     COMMAND ${CMAKE_COMMAND} -E make_directory "${TEST_DST_DIR}"


### PR DESCRIPTION
PR #2 highlighted a dynamic loading when building the R wrapper with shared objects on Windows/MSYS before building the C++ tests: the latter were unable to load the shared library `lib${PROJECT_NAME}.dll` copied in the test binaries directory.

From tests in a virtual machine, I understood that building the R wrapper will overwrite one `lib${PROJECT_NAME}.dll.a` that is in fact used in the linking process of the C++ test binaries. As a consequence, the test binaries will look for `${PROJECT_NAME}.dll` and not `lib${PROJECT_NAME}.dll`  (use MSYS's `ldd` on the test binaries to check for that).

This PR reverts the previous workaround (shifting the order of the dependencies to build & link the C++ test binaries before the R wrapper) and introduces a DLL copy on Windows/MSYS in the `prepare_cpp` CMake custom target: we copy `lib${PROJECT_NAME}.dll` to `${PROJECT_NAME}.dll` inside the C++ test binaries directory (both might be needed depending on `BUILD_TESTING` vs. `BUILD_R`).

Enjoy,
Pierre