### PR TITLE
Fix R package for MacOS-14 and Windows-2025

### DIFF
--- a/.github/workflows/publish_r_macos.yml
+++ b/.github/workflows/publish_r_macos.yml
@@ -69,9 +69,19 @@ jobs:
           -DSWIG_EXECUTABLE=${{env.SWIG_ROOT}}/bin/swig
 
     - name : Build the package and save generated file name in the environment
+      env :
+        OS_TYPE : ${{matrix.arch.os}}
+        R_VERSION : ${{matrix.r_version}}
       run : |
         cmake --build ${{env.BUILD_DIR}} --parallel 3 --target r_install
-        echo "MY_PKG=$(ls ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/swigex0_*.tgz)" >> "$GITHUB_ENV"
+        PKG_ARCHIVE=$(ls ${{env.BUILD_DIR}}/r/${{env.CMAKE_BUILD_TYPE}}/swigex0_*.tgz)
+        echo "Archive file is $PKG_ARCHIVE and OS_TYPE is $OS_TYPE"
+        if [ "$OS_TYPE" = "macos-14" && "$R_VERSION" = "4.6.0" ]; then
+          tar -xzf $PKG_ARCHIVE
+          sed -i '' 's/darwin23/darwin20/g' swigex0/DESCRIPTION
+          tar -czf $PKG_ARCHIVE swigex0
+        fi
+        echo "MY_PKG=$PKG_ARCHIVE" >> "$GITHUB_ENV"
 
     - uses: actions/upload-artifact@v6
       # Use specific artifact identifier for publishing all versions
@@ -105,7 +115,7 @@ jobs:
         r-version: ${{matrix.r_version}}
 
     - name: Install R package
-      run: Rscript -e "install.packages(\"$(ls *.tgz)\", repos=NULL, type='source')"
+      run: Rscript -e "install.packages(\"$(ls *.tgz)\", repos=NULL)"
 
     - name: Test installed R package
       run: |

--- a/.github/workflows/publish_r_windows.yml
+++ b/.github/workflows/publish_r_windows.yml
@@ -32,25 +32,28 @@ env:
 jobs:
 
   build:
-    runs-on: windows-2022
+    runs-on: ${{matrix.arch.os}}
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.3, 4.6.0]
+        arch: [
+            {gen: "Visual Studio 18 2026", os: windows-2025}
+         ]
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Setup R Version
-      uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: ${{matrix.r_version}}
 
     - name: Install the customized SWIG from source
       uses: fabien-ors/install-swig-windows-action@v3
       with:
         swig-root: ${{env.SWIG_ROOT}}
-        generator: "Visual Studio 17 2022"
+        generator: ${{matrix.arch.gen}}
+
+    - name: Setup R Version
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: ${{matrix.r_version}}
 
     - name : Configure build directory
       run : |
@@ -74,11 +77,12 @@ jobs:
 
   test:
     needs: build
-    runs-on: windows-2022
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
         # Last releases from here https://cran.r-project.org/src/base/R-4/
         r_version: [4.2.3, 4.3.3, 4.4.3, 4.5.3, 4.6.0]
+        os: [windows-2025]
 
     steps:
     - uses: actions/checkout@v4
@@ -93,7 +97,7 @@ jobs:
         r-version: ${{matrix.r_version}}
 
     - name: Install R package
-      run: Rscript -e "install.packages(""'""./$(ls *.zip)""'"", repos=NULL, type='source')"
+      run: Rscript -e "install.packages(""'""./$(ls *.zip)""'"", repos=NULL)"
       shell: bash
 
     - name: Test installed R package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Define project here
 project(swigex0
-        VERSION      0.4.3
+        VERSION      0.4.4
         DESCRIPTION  "C++ library and SWIG wrappers (R & Python)"
         HOMEPAGE_URL "https://github.com/fabien-ors/swigex0"
         LANGUAGES    C CXX) # Enable C language for third party libraries


### PR DESCRIPTION
- Fix the "add package" procedure in our CRAN for R packages under MacOS 14 with R 4.6.0.
- Build R package using windows-2025 (in place of windows-2022) because previous windows package was not able to load under windows-2025
- Upgrade version to 0.4.4